### PR TITLE
Refactor handlers

### DIFF
--- a/actuator/configuration.go
+++ b/actuator/configuration.go
@@ -91,11 +91,11 @@ func (c *Configuration) LoadConfigFile(fs afero.Fs, config *Configuration) error
 }
 
 // GetRepositoryConfig returns the configuration for the repository with the given name
-func (c *Configuration) GetRepositoryConfig(fullname string) *RepositoryConfig {
+func (c *Configuration) GetRepositoryConfig(fullname string) (RepositoryConfig, bool) {
 	for _, repo := range c.Repositories {
 		if repo.Fullname == fullname {
-			return &repo
+			return repo, true
 		}
 	}
-	return nil
+	return RepositoryConfig{Fullname: fullname, Enabled: false}, false
 }

--- a/actuator/configuration_test.go
+++ b/actuator/configuration_test.go
@@ -97,12 +97,19 @@ func TestGetRepositoryConfig(t *testing.T) {
 	repositories := []actuator.RepositoryConfig{repoConfig}
 	config := actuator.Configuration{Repositories: repositories}
 
-	assert.Equal(t, &repoConfig, config.GetRepositoryConfig("ninech/actuator"))
+	foundConfig, ok := config.GetRepositoryConfig("ninech/actuator")
+
+	assert.Equal(t, repoConfig, foundConfig)
+	assert.True(t, ok)
 }
 
 func TestGetRepositoryConfigNotFound(t *testing.T) {
 	repositories := []actuator.RepositoryConfig{}
 	config := actuator.Configuration{Repositories: repositories}
 
-	assert.Nil(t, config.GetRepositoryConfig("ninech/actuator"))
+	foundConfig, ok := config.GetRepositoryConfig("ninech/actuator")
+
+	assert.False(t, foundConfig.Enabled)
+	assert.Equal(t, "ninech/actuator", foundConfig.Fullname)
+	assert.False(t, ok)
 }

--- a/actuator/event_dispatcher.go
+++ b/actuator/event_dispatcher.go
@@ -11,9 +11,6 @@ type EventResponse struct {
 	// HandleEvent tells the receiver if the event should actually be handled
 	// if not, the the HandleEvent method should not be called
 	HandleEvent bool
-
-	// Data contains some additional data which was gathered during the answering process
-	Data map[string]interface{}
 }
 
 // EventHandler is an interface for every event handler in the system
@@ -22,27 +19,26 @@ type EventHandler interface {
 	// to do the heavy work as in most cases the caller of the endpoint doesn't care if the work
 	// involved succeeded or not. It's just interested if the hook was received correctly and
 	// can be handled.
-	GetEventResponse() *EventResponse
+	GetEventResponse(event *github.Event) *EventResponse
 
 	// HandleEvent does the actual work of handling an event. The result of this operation will
 	// be logged but not returned to the caller. This makes it possible to do the heavy work
 	// in the background and get a fast response for the caller of the hook.
-	HandleEvent()
+	HandleEvent(event *github.Event)
 }
 
 // EventDispatcher is responsible to find the right handler for an incoming
 // Github event. It then forwards the request to the respective handler.
 type EventDispatcher struct {
-	Event             github.Event
 	LastEventHandler  EventHandler
 	LastEventResponse *EventResponse
 }
 
 // GetEventResponse looks for an appropriate handler to care for this event. It then
 // calls its GetEventResponse method and returns the data.
-func (d *EventDispatcher) GetEventResponse() *EventResponse {
-	handler := d.FindEventHandler()
-	response := handler.GetEventResponse()
+func (d *EventDispatcher) GetEventResponse(event *github.Event) *EventResponse {
+	handler := d.FindEventHandler(event)
+	response := handler.GetEventResponse(event)
 
 	d.LastEventHandler = handler
 	d.LastEventResponse = response
@@ -51,17 +47,17 @@ func (d *EventDispatcher) GetEventResponse() *EventResponse {
 }
 
 // HandleEvent dispatches the call to the last used event handler
-func (d *EventDispatcher) HandleEvent() {
+func (d *EventDispatcher) HandleEvent(event *github.Event) {
 	if d.LastEventHandler != nil {
-		d.LastEventHandler.HandleEvent()
+		d.LastEventHandler.HandleEvent(event)
 	}
 }
 
 // FindEventHandler finds a handler for the provided event
-func (d *EventDispatcher) FindEventHandler() EventHandler {
-	switch d.Event.Type {
+func (d *EventDispatcher) FindEventHandler(event *github.Event) EventHandler {
+	switch event.Type {
 	case github.PullRequestEvent:
-		return NewPullRequestEventHandler(d.Event)
+		return NewPullRequestEventHandler(*event)
 	default:
 		return NewGenericEventHandler()
 	}

--- a/actuator/event_dispatcher.go
+++ b/actuator/event_dispatcher.go
@@ -1,0 +1,68 @@
+package actuator
+
+import "github.com/ninech/actuator/github"
+
+// EventResponse is returned from a handler's GetEventResponse method
+// and contains information to be passed to the sender of the hook
+type EventResponse struct {
+	// Message can be returned to the sender of the hook
+	Message string
+
+	// HandleEvent tells the receiver if the event should actually be handled
+	// if not, the the HandleEvent method should not be called
+	HandleEvent bool
+
+	// Data contains some additional data which was gathered during the answering process
+	Data map[string]interface{}
+}
+
+// EventHandler is an interface for every event handler in the system
+type EventHandler interface {
+	// GetEventResponse gets a response for the sender of the hook. This method doesn't have
+	// to do the heavy work as in most cases the caller of the endpoint doesn't care if the work
+	// involved succeeded or not. It's just interested if the hook was received correctly and
+	// can be handled.
+	GetEventResponse() *EventResponse
+
+	// HandleEvent does the actual work of handling an event. The result of this operation will
+	// be logged but not returned to the caller. This makes it possible to do the heavy work
+	// in the background and get a fast response for the caller of the hook.
+	HandleEvent()
+}
+
+// EventDispatcher is responsible to find the right handler for an incoming
+// Github event. It then forwards the request to the respective handler.
+type EventDispatcher struct {
+	Event             github.Event
+	LastEventHandler  EventHandler
+	LastEventResponse *EventResponse
+}
+
+// GetEventResponse looks for an appropriate handler to care for this event. It then
+// calls its GetEventResponse method and returns the data.
+func (d *EventDispatcher) GetEventResponse() *EventResponse {
+	handler := d.FindEventHandler()
+	response := handler.GetEventResponse()
+
+	d.LastEventHandler = handler
+	d.LastEventResponse = response
+
+	return response
+}
+
+// HandleEvent dispatches the call to the last used event handler
+func (d *EventDispatcher) HandleEvent() {
+	if d.LastEventHandler != nil {
+		d.LastEventHandler.HandleEvent()
+	}
+}
+
+// FindEventHandler finds a handler for the provided event
+func (d *EventDispatcher) FindEventHandler() EventHandler {
+	switch d.Event.Type {
+	case github.PullRequestEvent:
+		return NewPullRequestEventHandler(d.Event)
+	default:
+		return NewGenericEventHandler()
+	}
+}

--- a/actuator/event_dispatcher_test.go
+++ b/actuator/event_dispatcher_test.go
@@ -1,0 +1,56 @@
+package actuator_test
+
+import (
+	"testing"
+
+	"github.com/ninech/actuator/actuator"
+	"github.com/ninech/actuator/github"
+	"github.com/ninech/actuator/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventDispatcher(t *testing.T) {
+	event := test.NewDefaultTestEvent()
+
+	t.Run("GetEventResponse", func(t *testing.T) {
+		event.Type = 999
+
+		dispatcher := actuator.EventDispatcher{Event: *event}
+
+		response := dispatcher.GetEventResponse()
+
+		assert.Equal(t, "Request received. Doing nothing.", response.Message)
+		assert.IsType(t, &actuator.GenericEventHandler{}, dispatcher.LastEventHandler)
+	})
+
+	t.Run("HandleEvent", func(t *testing.T) {
+		handler := test.NewMockEventHandler("yay!")
+		dispatcher := actuator.EventDispatcher{
+			Event:            *event,
+			LastEventHandler: handler}
+
+		dispatcher.HandleEvent()
+
+		assert.True(t, handler.EventWasHandled)
+	})
+
+	t.Run("FindEventHandler", func(t *testing.T) {
+		t.Run("PullRequestEvent", func(t *testing.T) {
+			event.Type = github.PullRequestEvent
+			dispatcher := actuator.EventDispatcher{Event: *event}
+
+			handler := dispatcher.FindEventHandler()
+
+			assert.IsType(t, &actuator.PullRequestEventHandler{}, handler)
+		})
+
+		t.Run("any other event type", func(t *testing.T) {
+			event.Type = 999
+			dispatcher := actuator.EventDispatcher{Event: *event}
+
+			handler := dispatcher.FindEventHandler()
+
+			assert.IsType(t, &actuator.GenericEventHandler{}, handler)
+		})
+	})
+}

--- a/actuator/event_dispatcher_test.go
+++ b/actuator/event_dispatcher_test.go
@@ -15,9 +15,9 @@ func TestEventDispatcher(t *testing.T) {
 	t.Run("GetEventResponse", func(t *testing.T) {
 		event.Type = 999
 
-		dispatcher := actuator.EventDispatcher{Event: *event}
+		dispatcher := actuator.EventDispatcher{}
 
-		response := dispatcher.GetEventResponse()
+		response := dispatcher.GetEventResponse(event)
 
 		assert.Equal(t, "Request received. Doing nothing.", response.Message)
 		assert.IsType(t, &actuator.GenericEventHandler{}, dispatcher.LastEventHandler)
@@ -25,11 +25,9 @@ func TestEventDispatcher(t *testing.T) {
 
 	t.Run("HandleEvent", func(t *testing.T) {
 		handler := test.NewMockEventHandler("yay!")
-		dispatcher := actuator.EventDispatcher{
-			Event:            *event,
-			LastEventHandler: handler}
+		dispatcher := actuator.EventDispatcher{LastEventHandler: handler}
 
-		dispatcher.HandleEvent()
+		dispatcher.HandleEvent(event)
 
 		assert.True(t, handler.EventWasHandled)
 	})
@@ -37,18 +35,18 @@ func TestEventDispatcher(t *testing.T) {
 	t.Run("FindEventHandler", func(t *testing.T) {
 		t.Run("PullRequestEvent", func(t *testing.T) {
 			event.Type = github.PullRequestEvent
-			dispatcher := actuator.EventDispatcher{Event: *event}
+			dispatcher := actuator.EventDispatcher{}
 
-			handler := dispatcher.FindEventHandler()
+			handler := dispatcher.FindEventHandler(event)
 
 			assert.IsType(t, &actuator.PullRequestEventHandler{}, handler)
 		})
 
 		t.Run("any other event type", func(t *testing.T) {
 			event.Type = 999
-			dispatcher := actuator.EventDispatcher{Event: *event}
+			dispatcher := actuator.EventDispatcher{}
 
-			handler := dispatcher.FindEventHandler()
+			handler := dispatcher.FindEventHandler(event)
 
 			assert.IsType(t, &actuator.GenericEventHandler{}, handler)
 		})

--- a/actuator/event_endpoint.go
+++ b/actuator/event_endpoint.go
@@ -11,11 +11,6 @@ type WebhookParser interface {
 	ValidateAndParseWebhook(*http.Request) (interface{}, error)
 }
 
-// EventHandler defines an interface for all event handlers
-type EventHandler interface {
-	HandleEvent() (string, error)
-}
-
 // EventEndpoint is an api endpoint to handle Github event webhooks.
 // It needs a parser and an event handler
 type EventEndpoint struct {
@@ -34,29 +29,33 @@ func NewEventEndpoint(request *http.Request) *EventEndpoint {
 
 // Handle parses the request into a github event and handles it
 func (e *EventEndpoint) Handle() (int, interface{}) {
-	event, err := e.WebhookParser.ValidateAndParseWebhook(e.Request)
+	githubEvent, err := e.WebhookParser.ValidateAndParseWebhook(e.Request)
 	if err != nil {
 		return 400, gin.H{"message": err.Error()}
 	}
 
-	if e.EventHandler == nil {
-		e.EventHandler = e.getHandlerForEvent(event)
+	event, ok := github.ConvertGithubEvent(githubEvent)
+	if !ok {
+		return 400, gin.H{"message": "Invalid or unsupported event payload."}
 	}
 
-	message, handleError := e.EventHandler.HandleEvent()
-	if handleError != nil {
-		Logger.Println(handleError.Error())
-		return 500, gin.H{"message": message}
+	dispatcher := EventDispatcher{Event: *event}
+	response := dispatcher.GetEventResponse()
+
+	if response.HandleEvent {
+		dispatcher.HandleEvent()
 	}
 
-	return 200, gin.H{"message": message}
+	return 200, gin.H{"message": response.Message}
 }
 
 func (e *EventEndpoint) getHandlerForEvent(githubEvent interface{}) EventHandler {
 	if event, ok := github.ConvertGithubEvent(githubEvent); ok {
 		switch event.Type {
 		case github.PullRequestEvent:
-			return NewPullRequestEventHandler(event, Config)
+			return NewPullRequestEventHandler(*event)
+		default:
+			return NewGenericEventHandler()
 		}
 	}
 	return &GenericEventHandler{}

--- a/actuator/event_endpoint_test.go
+++ b/actuator/event_endpoint_test.go
@@ -6,48 +6,51 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/go-github/github"
+	gh "github.com/google/go-github/github"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ninech/actuator/actuator"
 	"github.com/ninech/actuator/test"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateRequestFails(t *testing.T) {
-	parser := MockWebhookParser{ValidRequest: false}
-	endpoint := actuator.EventEndpoint{WebhookParser: &parser}
+func TestEventEndpoint(t *testing.T) {
+	t.Run("Handle", func(t *testing.T) {
+		t.Run("validate request fails", func(t *testing.T) {
+			parser := MockWebhookParser{ValidRequest: false}
+			endpoint := actuator.EventEndpoint{WebhookParser: &parser}
 
-	code, message := endpoint.Handle()
-	assert.Equal(t, http.StatusBadRequest, code)
-	assert.Equal(t, gin.H{"message": "Request validation failed."}, message)
-}
+			code, message := endpoint.Handle()
+			assert.Equal(t, http.StatusBadRequest, code)
+			assert.Equal(t, gin.H{"message": "Request validation failed."}, message)
+		})
 
-func TestValidRequestPullRequestEvent(t *testing.T) {
-	handler := test.NewMockEventHandler("success!")
-	parser := MockWebhookParser{ValidRequest: true}
-	endpoint := actuator.EventEndpoint{
-		WebhookParser: &parser,
-		EventHandler:  handler}
-	parser.SetEventData(1, "opened")
+		t.Run("with an unsupported event type", func(t *testing.T) {
+			parser := MockWebhookParser{ValidRequest: true, Event: &gh.IssueEvent{}}
+			endpoint := actuator.EventEndpoint{
+				WebhookParser: &parser}
 
-	t.Skip("validate test")
+			code, message := endpoint.Handle()
+			assert.Equal(t, gin.H{"message": "Invalid or unsupported event payload."}, message)
+			assert.Equal(t, http.StatusBadRequest, code)
+		})
 
-	code, message := endpoint.Handle()
-	assert.True(t, handler.EventWasHandled)
-	assert.Equal(t, "tbd", message)
-	assert.Equal(t, http.StatusOK, code)
-}
+		t.Run("with a valid event", func(t *testing.T) {
+			parser := MockWebhookParser{ValidRequest: true}
+			parser.Event = test.NewDefaultOriginalPullRequestEvent(1, "opened")
 
-func TestUnsupportedEventType(t *testing.T) {
-	handler := test.NewMockEventHandler("unsupported!")
-	parser := MockWebhookParser{ValidRequest: true, Event: &github.IssueEvent{}}
-	endpoint := actuator.EventEndpoint{
-		WebhookParser: &parser,
-		EventHandler:  handler}
+			handler := test.NewMockEventHandler("All is fine!")
+			handler.EventResponse.HandleEvent = true
 
-	code, message := endpoint.Handle()
-	assert.False(t, handler.EventWasHandled)
-	assert.Equal(t, gin.H{"message": "Invalid or unsupported event payload."}, message)
-	assert.Equal(t, http.StatusBadRequest, code)
+			endpoint := actuator.EventEndpoint{
+				WebhookParser: &parser,
+				EventHandler:  handler}
+
+			code, message := endpoint.Handle()
+			assert.Equal(t, gin.H{"message": "All is fine!"}, message)
+			assert.Equal(t, http.StatusOK, code)
+			assert.True(t, handler.EventWasHandled)
+		})
+	})
 }
 
 /// HELPERS ////
@@ -62,8 +65,4 @@ func (p *MockWebhookParser) ValidateAndParseWebhook(request *http.Request) (inte
 		return p.Event, nil
 	}
 	return nil, errors.New("Request validation failed.")
-}
-
-func (p *MockWebhookParser) SetEventData(number int, action string) {
-	p.Event = &github.PullRequestEvent{Number: &number, Action: &action}
 }

--- a/actuator/event_endpoint_test.go
+++ b/actuator/event_endpoint_test.go
@@ -22,7 +22,7 @@ func TestValidateRequestFails(t *testing.T) {
 }
 
 func TestValidRequestPullRequestEvent(t *testing.T) {
-	handler := MockGithubEventHandler{Message: "success!"}
+	handler := test.NewMockEventHandler("success!")
 	parser := MockWebhookParser{ValidRequest: true}
 	endpoint := actuator.EventEndpoint{
 		WebhookParser: &parser,
@@ -35,7 +35,7 @@ func TestValidRequestPullRequestEvent(t *testing.T) {
 }
 
 func TestUnsupportedEventType(t *testing.T) {
-	handler := MockGithubEventHandler{Message: "unsupported!"}
+	handler := test.NewMockEventHandler("unsupported!")
 	parser := MockWebhookParser{ValidRequest: true, Event: &github.IssueEvent{}}
 	endpoint := actuator.EventEndpoint{
 		WebhookParser: &parser,
@@ -77,17 +77,4 @@ func (p *MockWebhookParser) ValidateAndParseWebhook(request *http.Request) (inte
 
 func (p *MockWebhookParser) SetEventData(number int, action string) {
 	p.Event = &github.PullRequestEvent{Number: &number, Action: &action}
-}
-
-type MockGithubEventHandler struct {
-	Error   error
-	Message string
-}
-
-func (h *MockGithubEventHandler) HandleEvent() (string, error) {
-	message := h.Message
-	if message == "" {
-		message = h.Error.Error()
-	}
-	return message, h.Error
 }

--- a/actuator/generic_event_handler.go
+++ b/actuator/generic_event_handler.go
@@ -1,5 +1,7 @@
 package actuator
 
+import "github.com/ninech/actuator/github"
+
 // GenericEventHandler is a simple event handler that does nothing
 type GenericEventHandler struct{}
 
@@ -8,11 +10,11 @@ func NewGenericEventHandler() *GenericEventHandler {
 }
 
 // GetEventResponse just returns a generic message. The hook was received but doing nothing in this case.
-func (h *GenericEventHandler) GetEventResponse() *EventResponse {
+func (h *GenericEventHandler) GetEventResponse(event *github.Event) *EventResponse {
 	return &EventResponse{Message: "Request received. Doing nothing."}
 }
 
 // HandleEvent does nothing
-func (h *GenericEventHandler) HandleEvent() {
+func (h *GenericEventHandler) HandleEvent(event *github.Event) {
 	return
 }

--- a/actuator/generic_event_handler.go
+++ b/actuator/generic_event_handler.go
@@ -3,7 +3,16 @@ package actuator
 // GenericEventHandler is a simple event handler that does nothing
 type GenericEventHandler struct{}
 
-// HandleEvent just return a message that it does nothing
-func (h *GenericEventHandler) HandleEvent() (string, error) {
-	return "Not processing this type of event", nil
+func NewGenericEventHandler() *GenericEventHandler {
+	return &GenericEventHandler{}
+}
+
+// GetEventResponse just returns a generic message. The hook was received but doing nothing in this case.
+func (h *GenericEventHandler) GetEventResponse() *EventResponse {
+	return &EventResponse{Message: "Request received. Doing nothing."}
+}
+
+// HandleEvent does nothing
+func (h *GenericEventHandler) HandleEvent() {
+	return
 }

--- a/actuator/generic_event_handler_test.go
+++ b/actuator/generic_event_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ninech/actuator/actuator"
+	"github.com/ninech/actuator/github"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -11,13 +12,13 @@ import (
 func TestGenericEventHandler(t *testing.T) {
 	t.Run("GetEventResponse", func(t *testing.T) {
 		handler := actuator.NewGenericEventHandler()
-		response := handler.GetEventResponse()
+		response := handler.GetEventResponse(&github.Event{})
 
 		assert.Equal(t, "Request received. Doing nothing.", response.Message)
 	})
 
 	t.Run("HandleEvent", func(t *testing.T) {
 		handler := actuator.NewGenericEventHandler()
-		handler.HandleEvent()
+		handler.HandleEvent(&github.Event{})
 	})
 }

--- a/actuator/generic_event_handler_test.go
+++ b/actuator/generic_event_handler_test.go
@@ -3,16 +3,21 @@ package actuator_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ninech/actuator/actuator"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestHandleEvent(t *testing.T) {
-	handler := actuator.GenericEventHandler{}
+func TestGenericEventHandler(t *testing.T) {
+	t.Run("GetEventResponse", func(t *testing.T) {
+		handler := actuator.NewGenericEventHandler()
+		response := handler.GetEventResponse()
 
-	message, err := handler.HandleEvent()
+		assert.Equal(t, "Request received. Doing nothing.", response.Message)
+	})
 
-	assert.Equal(t, "Not processing this type of event", message)
-	assert.Nil(t, err)
+	t.Run("HandleEvent", func(t *testing.T) {
+		handler := actuator.NewGenericEventHandler()
+		handler.HandleEvent()
+	})
 }

--- a/actuator/pull_request_event_handler.go
+++ b/actuator/pull_request_event_handler.go
@@ -11,15 +11,8 @@ import (
 	"github.com/ninech/actuator/openshift"
 )
 
-// SupportedPullRequestActions defines all pull request event actions which are supported by this app.
-const (
-	ActionOpened   = "opened"
-	ActionClosed   = "closed"
-	ActionReopened = "reopened"
-)
-
 // SupportedPullRequestActions defines all actions which are currently supported to be handled
-var SupportedPullRequestActions = [2]string{ActionOpened, ActionClosed}
+var SupportedPullRequestActions = [2]string{github.EventActionOpened, github.EventActionClosed}
 
 // PullRequestEventHandler handles pull request events
 type PullRequestEventHandler struct {

--- a/actuator/pull_request_event_handler.go
+++ b/actuator/pull_request_event_handler.go
@@ -33,7 +33,8 @@ func NewPullRequestEventHandler(event github.Event) *PullRequestEventHandler {
 }
 
 // GetEventResponse validates the event and checks if it can be handled.
-func (h *PullRequestEventHandler) GetEventResponse() *EventResponse {
+func (h *PullRequestEventHandler) GetEventResponse(event *github.Event) *EventResponse {
+	h.Event = *event
 	response := &EventResponse{}
 
 	if h.Event.Type != github.PullRequestEvent {
@@ -57,7 +58,8 @@ func (h *PullRequestEventHandler) GetEventResponse() *EventResponse {
 }
 
 // HandleEvent handles a pull request event from github
-func (h *PullRequestEventHandler) HandleEvent() {
+func (h *PullRequestEventHandler) HandleEvent(event *github.Event) {
+	h.Event = *event
 	Logger.Printf("Starting to handle action %v.", h.Event.Action)
 
 	var err error
@@ -71,7 +73,7 @@ func (h *PullRequestEventHandler) HandleEvent() {
 	}
 
 	if err != nil {
-		Logger.Println(err.Error())
+		Logger.Printf("There were some errors while handling the event.\n%v", err)
 	} else {
 		Logger.Printf("%v action handled without errors.", h.Event.Action)
 	}

--- a/actuator/pull_request_event_handler_test.go
+++ b/actuator/pull_request_event_handler_test.go
@@ -7,101 +7,108 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ninech/actuator/actuator"
+	"github.com/ninech/actuator/github"
 	"github.com/ninech/actuator/openshift"
 	"github.com/ninech/actuator/test"
 )
 
-func TestHandleEventFails(t *testing.T) {
-	t.Run("the event's repository is not configured", func(t *testing.T) {
-		event := test.NewTestEvent(1, actuator.ActionOpened, "ninech/yoloproject")
-		handler := actuator.PullRequestEventHandler{Event: event}
+var ensurePullRequestEventHandlerImplementsEventHandler actuator.EventHandler = &actuator.PullRequestEventHandler{}
 
-		message, err := handler.HandleEvent()
-		assert.Nil(t, err)
-		assert.Equal(t, "Repository ninech/yoloproject is not configured. Doing nothing.", message)
+func TestPullRequestEventHandler(t *testing.T) {
+	t.Run("GetEventResponse", func(t *testing.T) {
+		t.Run("the event's repository is not configured", func(t *testing.T) {
+			event := test.NewTestEvent(1, github.EventActionOpened, "ninech/yoloproject")
+			handler := actuator.PullRequestEventHandler{Event: *event}
+
+			response := handler.GetEventResponse()
+			assert.False(t, response.HandleEvent)
+			assert.Equal(t, "Repository ninech/yoloproject is not configured or disabled. Doing nothing.", response.Message)
+		})
+
+		t.Run("the event repository is disabled in the config file", func(t *testing.T) {
+			actuator.Config = test.NewDefaultConfig()
+			actuator.Config.Repositories[0].Enabled = false
+
+			event := test.NewTestEvent(1, github.EventActionOpened, actuator.Config.Repositories[0].Fullname)
+			handler := actuator.PullRequestEventHandler{Event: *event}
+
+			response := handler.GetEventResponse()
+			assert.False(t, response.HandleEvent)
+			assert.Equal(t, "Repository ninech/actuator is not configured or disabled. Doing nothing.", response.Message)
+		})
+
+		t.Run("the action is not supported", func(t *testing.T) {
+			event := test.NewTestEvent(1, "yolo", "ninech/actuator")
+			handler := actuator.PullRequestEventHandler{Event: *event}
+
+			response := handler.GetEventResponse()
+			assert.False(t, response.HandleEvent)
+			assert.Equal(t, "Event is not relevant and will be ignored.", response.Message)
+		})
 	})
 
-	t.Run("the event repository is disabled in the config file", func(t *testing.T) {
-		config := test.NewDefaultConfig()
-		config.Repositories[0].Enabled = false
+	t.Run("HandleEvent", func(t *testing.T) {
+		t.Run("EventActionOpened", func(t *testing.T) {
+			test.DisableLogging()
 
-		event := test.NewTestEvent(1, actuator.ActionOpened, config.Repositories[0].Fullname)
-		handler := actuator.PullRequestEventHandler{Event: event, Config: config}
+			event := test.NewTestEvent(1, github.EventActionOpened, "ninech/actuator")
+			githubClient := test.NewMockGithubClient()
+			openshiftClient := &test.OpenshiftMock{}
+			repositoryConfig := actuator.RepositoryConfig{Template: "actuator-template"}
 
-		message, _ := handler.HandleEvent()
-		assert.Contains(t, message, "is disabled.")
-	})
+			actuator.Config = test.NewDefaultConfig()
 
-	t.Run("the action is not supported", func(t *testing.T) {
-		event := test.NewTestEvent(1, "yolo", "ninech/actuator")
-		handler := actuator.PullRequestEventHandler{Event: event}
+			handler := actuator.PullRequestEventHandler{
+				Event:            *event,
+				RepositoryConfig: repositoryConfig,
+				GithubClient:     githubClient,
+				Openshift:        openshiftClient}
 
-		_, err := handler.HandleEvent()
-		assert.Nil(t, err)
-	})
-}
+			t.Run("applies the template in openshift", func(t *testing.T) {
+				handler.HandleEvent()
 
-func TestHandleEventActionOpened(t *testing.T) {
-	test.DisableLogging()
+				assert.Equal(t, repositoryConfig.Template, openshiftClient.AppliedTemplate, "it instantiates the template from the config")
 
-	event := test.NewTestEvent(1, actuator.ActionOpened, "ninech/actuator")
-	config := test.NewDefaultConfig()
-	githubClient := test.NewMockGithubClient()
-	openshiftClient := &test.OpenshiftMock{}
+				assert.Equal(t, openshiftClient.AppliedLabels["actuator.nine.ch/create-reason"], "GithubWebhook")
+				assert.Equal(t, openshiftClient.AppliedLabels["actuator.nine.ch/branch"], event.HeadRef)
+				assert.Equal(t, openshiftClient.AppliedLabels["actuator.nine.ch/pull-request"], strconv.Itoa(event.IssueNumber))
 
-	handler := actuator.PullRequestEventHandler{
-		Event:        event,
-		Config:       config,
-		GithubClient: githubClient,
-		Openshift:    openshiftClient}
+				assert.Equal(t, openshiftClient.AppliedParameters["BRANCH_NAME"], "pr-1")
+			})
 
-	t.Run("applies the template in openshift", func(t *testing.T) {
-		message, err := handler.HandleEvent()
-		assert.Nil(t, err)
-		assert.Equal(t, "Event for pull request #1 received. Thank you.", message)
-		assert.Equal(t, config.GetRepositoryConfig(event.RepositoryFullname).Template, openshiftClient.AppliedTemplate, "it instantiates the template from the config")
+			t.Run("writes a comment on github", func(t *testing.T) {
+				handler.HandleEvent()
+				githubComment := githubClient.LastComment
+				assert.NotNil(t, githubComment, "creates a comment on github")
+				assert.Equal(t, "Your environment is being set-up on Openshift. There is no route I can point you to.", githubComment.GetBody())
+				assert.Equal(t, "https://github.com/ninech/actuator/issues/1#issuecomment-330230087", githubComment.GetHTMLURL())
+			})
 
-		assert.Equal(t, openshiftClient.AppliedLabels["actuator.nine.ch/create-reason"], "GithubWebhook")
-		assert.Equal(t, openshiftClient.AppliedLabels["actuator.nine.ch/branch"], event.HeadRef)
-		assert.Equal(t, openshiftClient.AppliedLabels["actuator.nine.ch/pull-request"], strconv.Itoa(event.IssueNumber))
+			t.Run("posts the url as comment", func(t *testing.T) {
+				openshiftClient.NewAppOutputToReturn = openshift.NewAppOutput{Raw: `route "actuator" created`}
+				handler.HandleEvent()
 
-		assert.Equal(t, openshiftClient.AppliedParameters["BRANCH_NAME"], "pr-1")
-	})
+				githubComment := githubClient.LastComment
+				assert.Equal(t, "Your environment is being set-up on Openshift. http://actuator.domain.com", githubComment.GetBody())
+			})
+		})
 
-	t.Run("writes a comment on github", func(t *testing.T) {
-		handler.HandleEvent()
-		githubComment := githubClient.LastComment
-		assert.NotNil(t, githubComment, "creates a comment on github")
-		assert.Equal(t, "Your environment is being set-up on Openshift. There is no route I can point you to.", githubComment.GetBody())
-		assert.Equal(t, "https://github.com/ninech/actuator/issues/1#issuecomment-330230087", githubComment.GetHTMLURL())
-	})
+		t.Run("EventActionClosed", func(t *testing.T) {
+			test.DisableLogging()
 
-	t.Run("posts the url as comment", func(t *testing.T) {
-		openshiftClient.NewAppOutputToReturn = openshift.NewAppOutput{Raw: `route "actuator" created`}
-		handler.HandleEvent()
+			actuator.Config = test.NewDefaultConfig()
+			event := test.NewTestEvent(1, github.EventActionClosed, "ninech/actuator")
+			openshiftClient := &test.OpenshiftMock{}
 
-		githubComment := githubClient.LastComment
-		assert.Equal(t, "Your environment is being set-up on Openshift. http://actuator.domain.com", githubComment.GetBody())
-	})
-}
+			handler := actuator.PullRequestEventHandler{
+				Event:     *event,
+				Openshift: openshiftClient}
 
-func TestHandleEventActionClosed(t *testing.T) {
-	test.DisableLogging()
+			t.Run("deletes the objects in openshift", func(t *testing.T) {
+				handler.HandleEvent()
 
-	event := test.NewTestEvent(1, actuator.ActionClosed, "ninech/actuator")
-	config := test.NewDefaultConfig()
-	openshiftClient := &test.OpenshiftMock{}
-
-	handler := actuator.PullRequestEventHandler{
-		Event:     event,
-		Config:    config,
-		Openshift: openshiftClient}
-
-	t.Run("deletes the objects in openshift", func(t *testing.T) {
-		message, err := handler.HandleEvent()
-
-		assert.Nil(t, err)
-		assert.Equal(t, "Event for pull request #1 received. Thank you.", message)
-		assert.Equal(t, openshiftClient.DeletedLabels["actuator.nine.ch/pull-request"], strconv.Itoa(event.IssueNumber))
+				assert.Equal(t, openshiftClient.DeletedLabels["actuator.nine.ch/pull-request"], strconv.Itoa(event.IssueNumber))
+			})
+		})
 	})
 }

--- a/github/event.go
+++ b/github/event.go
@@ -23,6 +23,13 @@ type Event struct {
 	OriginalEvent interface{}
 }
 
+// SupportedPullRequestActions defines all pull request event actions which are supported by this app.
+const (
+	EventActionOpened   = "opened"
+	EventActionClosed   = "closed"
+	EventActionReopened = "reopened"
+)
+
 // ConvertGithubEvent turns an original Github Event into the internal structure
 func ConvertGithubEvent(original interface{}) (*Event, bool) {
 	switch event := original.(type) {

--- a/test/mock_event_handler.go
+++ b/test/mock_event_handler.go
@@ -1,0 +1,21 @@
+package test
+
+import "github.com/ninech/actuator/actuator"
+
+func NewMockEventHandler(message string) *MockEventHandler {
+	response := actuator.EventResponse{Message: message}
+	return &MockEventHandler{EventResponse: response}
+}
+
+type MockEventHandler struct {
+	EventResponse   actuator.EventResponse
+	EventWasHandled bool
+}
+
+func (h *MockEventHandler) GetEventResponse() *actuator.EventResponse {
+	return &h.EventResponse
+}
+
+func (h *MockEventHandler) HandleEvent() {
+	h.EventWasHandled = true
+}

--- a/test/mock_event_handler.go
+++ b/test/mock_event_handler.go
@@ -1,6 +1,9 @@
 package test
 
-import "github.com/ninech/actuator/actuator"
+import (
+	"github.com/ninech/actuator/actuator"
+	"github.com/ninech/actuator/github"
+)
 
 func NewMockEventHandler(message string) *MockEventHandler {
 	response := actuator.EventResponse{Message: message}
@@ -10,12 +13,15 @@ func NewMockEventHandler(message string) *MockEventHandler {
 type MockEventHandler struct {
 	EventResponse   actuator.EventResponse
 	EventWasHandled bool
+	LastEvent       *github.Event
 }
 
-func (h *MockEventHandler) GetEventResponse() *actuator.EventResponse {
+func (h *MockEventHandler) GetEventResponse(event *github.Event) *actuator.EventResponse {
+	h.LastEvent = event
 	return &h.EventResponse
 }
 
-func (h *MockEventHandler) HandleEvent() {
+func (h *MockEventHandler) HandleEvent(event *github.Event) {
+	h.LastEvent = event
 	h.EventWasHandled = true
 }

--- a/test/object_builders.go
+++ b/test/object_builders.go
@@ -3,6 +3,8 @@ package test
 import (
 	"strings"
 
+	gh "github.com/google/go-github/github"
+
 	"github.com/ninech/actuator/actuator"
 	"github.com/ninech/actuator/github"
 )
@@ -29,4 +31,20 @@ func NewDefaultConfig() actuator.Configuration {
 		Exclude:  "master",
 		Template: "actuator-template"}
 	return actuator.Configuration{Repositories: []actuator.RepositoryConfig{repoConfig}}
+}
+
+func NewDefaultOriginalPullRequestEvent(number int, action string) *gh.PullRequestEvent {
+	login := "ninech"
+	name := "actuator"
+	fullname := "ninech/actuator"
+	owner := gh.User{Login: &login}
+	repo := gh.Repository{Owner: &owner, Name: &name, FullName: &fullname}
+	branch := "pr-1"
+	head := gh.PullRequestBranch{Ref: &branch}
+	pr := gh.PullRequest{Head: &head}
+	return &gh.PullRequestEvent{
+		Number:      &number,
+		Action:      &action,
+		Repo:        &repo,
+		PullRequest: &pr}
 }

--- a/test/object_builders.go
+++ b/test/object_builders.go
@@ -19,7 +19,7 @@ func NewTestEvent(number int, action string, repoName string) *github.Event {
 }
 
 func NewDefaultTestEvent() *github.Event {
-	return NewTestEvent(1, actuator.ActionOpened, "ninech/actuator")
+	return NewTestEvent(1, github.EventActionOpened, "ninech/actuator")
 }
 
 func NewDefaultConfig() actuator.Configuration {


### PR DESCRIPTION
Makes the event handlers a bit easier to test and it will be easier to add more handlers later.

An important change here is the separation of answering the hook and the actual handling of the event. Every handler can prepare an answer for the hook. This answer should not be dependent of the result of the actual handling. The sender of the hook should not be interested in any results of the hook. Therefore Actuator just checks if the request is valid and can theoretically be handled. 

The handling itself happens separately and will not be reported to the sender of the hook. This makes it possible to move the handling in the background to not block the process.