### PR TITLE
Handle event in the background

### DIFF
--- a/actuator/event_endpoint.go
+++ b/actuator/event_endpoint.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ninech/actuator/github"
 )
 
+// WebhookParser defines the interface of a parser of incomming data
 type WebhookParser interface {
 	ValidateAndParseWebhook(*http.Request) (interface{}, error)
 }
@@ -43,7 +44,7 @@ func (e *EventEndpoint) Handle() (int, interface{}) {
 	response := e.EventHandler.GetEventResponse(event)
 
 	if response.HandleEvent {
-		e.EventHandler.HandleEvent(event)
+		go e.EventHandler.HandleEvent(event)
 	}
 
 	return 200, gin.H{"message": response.Message}

--- a/actuator/event_endpoint_test.go
+++ b/actuator/event_endpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	gh "github.com/google/go-github/github"
@@ -41,11 +42,19 @@ func TestEventEndpoint(t *testing.T) {
 			handler := test.NewMockEventHandler("All is fine!")
 			handler.EventResponse.HandleEvent = true
 
-			endpoint := actuator.EventEndpoint{
-				WebhookParser: &parser,
-				EventHandler:  handler}
+			endpoint := actuator.NewEventEndpoint(nil)
+			endpoint.WebhookParser = &parser
+			endpoint.EventHandler = handler
 
 			code, message := endpoint.Handle()
+
+			// Wait until the handler is done
+			select {
+			case <-handler.Done:
+			case <-time.After(time.Second):
+				assert.Fail(t, "timed out while waiting for handler")
+			}
+
 			assert.Equal(t, gin.H{"message": "All is fine!"}, message)
 			assert.Equal(t, http.StatusOK, code)
 			assert.True(t, handler.EventWasHandled)

--- a/actuator/pull_request_event_handler.go
+++ b/actuator/pull_request_event_handler.go
@@ -62,11 +62,9 @@ func (h *PullRequestEventHandler) HandleEvent(event *github.Event) {
 	switch event.Action {
 	case github.EventActionOpened:
 		err = h.HandleActionOpened(event)
-		break
 	case github.EventActionClosed:
 		labels := openshift.ObjectLabels{"actuator.nine.ch/pull-request": strconv.Itoa(event.IssueNumber)}
 		err = h.DeleteEnvironmentOnOpenshift(&labels)
-		break
 	}
 
 	if err != nil {

--- a/test/mock_event_handler.go
+++ b/test/mock_event_handler.go
@@ -7,13 +7,15 @@ import (
 
 func NewMockEventHandler(message string) *MockEventHandler {
 	response := actuator.EventResponse{Message: message}
-	return &MockEventHandler{EventResponse: response}
+	done := make(chan bool, 1)
+	return &MockEventHandler{EventResponse: response, Done: done}
 }
 
 type MockEventHandler struct {
 	EventResponse   actuator.EventResponse
 	EventWasHandled bool
 	LastEvent       *github.Event
+	Done            chan bool
 }
 
 func (h *MockEventHandler) GetEventResponse(event *github.Event) *actuator.EventResponse {
@@ -24,4 +26,5 @@ func (h *MockEventHandler) GetEventResponse(event *github.Event) *actuator.Event
 func (h *MockEventHandler) HandleEvent(event *github.Event) {
 	h.LastEvent = event
 	h.EventWasHandled = true
+	h.Done <- true
 }


### PR DESCRIPTION
This PR moves the actual handling of an event into the background. The sender of the hook gets a confirmation if the hook will be treated. But then the actual handling of the event happens after the request.
This is needed because we don't want any long running tasks to block the request. And the sender of an event doesn't need to know the actual result.