### PR TITLE
Support the Github ping event

### DIFF
--- a/actuator/event_dispatcher.go
+++ b/actuator/event_dispatcher.go
@@ -58,6 +58,8 @@ func (d *EventDispatcher) FindEventHandler(event *github.Event) EventHandler {
 	switch event.Type {
 	case github.PullRequestEvent:
 		return NewPullRequestEventHandler(*event)
+	case github.PingEvent:
+		return NewPingEventHandler()
 	default:
 		return NewGenericEventHandler()
 	}

--- a/actuator/event_dispatcher_test.go
+++ b/actuator/event_dispatcher_test.go
@@ -42,6 +42,15 @@ func TestEventDispatcher(t *testing.T) {
 			assert.IsType(t, &actuator.PullRequestEventHandler{}, handler)
 		})
 
+		t.Run("PingEvent", func(t *testing.T) {
+			event.Type = github.PingEvent
+			dispatcher := actuator.EventDispatcher{}
+
+			handler := dispatcher.FindEventHandler(event)
+
+			assert.IsType(t, &actuator.PingEventHandler{}, handler)
+		})
+
 		t.Run("any other event type", func(t *testing.T) {
 			event.Type = 999
 			dispatcher := actuator.EventDispatcher{}

--- a/actuator/ping_event_handler.go
+++ b/actuator/ping_event_handler.go
@@ -1,0 +1,22 @@
+package actuator
+
+import "github.com/ninech/actuator/github"
+
+// PingEventHandler responds to ping events from github
+// https://developer.github.com/webhooks/#ping-event
+type PingEventHandler struct{}
+
+// NewPingEventHandler creates an empty PingEventHandler
+func NewPingEventHandler() *PingEventHandler {
+	return &PingEventHandler{}
+}
+
+// GetEventResponse just returns a generic message. The hook was received but doing nothing in this case.
+func (h *PingEventHandler) GetEventResponse(event *github.Event) *EventResponse {
+	return &EventResponse{Message: "Request received. Thank you."}
+}
+
+// HandleEvent does nothing
+func (h *PingEventHandler) HandleEvent(event *github.Event) {
+	return
+}

--- a/actuator/ping_event_handler_test.go
+++ b/actuator/ping_event_handler_test.go
@@ -1,0 +1,24 @@
+package actuator_test
+
+import (
+	"testing"
+
+	"github.com/ninech/actuator/actuator"
+	"github.com/ninech/actuator/github"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPingEventHandler(t *testing.T) {
+	t.Run("GetEventResponse", func(t *testing.T) {
+		handler := actuator.NewPingEventHandler()
+		response := handler.GetEventResponse(&github.Event{})
+
+		assert.Equal(t, "Request received. Thank you.", response.Message)
+	})
+
+	t.Run("HandleEvent", func(t *testing.T) {
+		handler := actuator.NewGenericEventHandler()
+		handler.HandleEvent(&github.Event{})
+	})
+}

--- a/examples/ping-event.json
+++ b/examples/ping-event.json
@@ -1,0 +1,31 @@
+{
+  "zen": "Non-blocking is better than blocking.",
+  "hook_id": 16288669,
+  "hook": {
+    "type": "Repository",
+    "id": 16288669,
+    "name": "web",
+    "active": true,
+    "events": [
+      "pull_request"
+    ],
+    "config": {
+      "content_type": "json",
+      "insecure_ssl": "0",
+      "secret": "********",
+      "url": "http://actuator.openshift-apps.staging.nine.ch"
+    },
+    "updated_at": "2017-09-21T07:36:48Z",
+    "created_at": "2017-09-21T07:36:48Z",
+    "url": "https://api.github.com/repos/ninech/actuator-demo/hooks/16288669",
+    "test_url": "https://api.github.com/repos/ninech/actuator-demo/hooks/16288669/test",
+    "ping_url": "https://api.github.com/repos/ninech/actuator-demo/hooks/16288669/pings",
+    "last_response": {
+      "code": null,
+      "status": "unused",
+      "message": null
+    }
+  },
+  "repository": {},
+  "sender": {}
+}

--- a/github/event.go
+++ b/github/event.go
@@ -8,6 +8,7 @@ type EventType int
 
 const (
 	PullRequestEvent EventType = iota
+	PingEvent
 )
 
 // Event is the internal structure used for an event
@@ -35,6 +36,8 @@ func ConvertGithubEvent(original interface{}) (*Event, bool) {
 	switch event := original.(type) {
 	case *gh.PullRequestEvent:
 		return convertPullRequestEvent(event), true
+	case *gh.PingEvent:
+		return &Event{Type: PingEvent, OriginalEvent: original}, true
 	default:
 		return nil, false
 	}

--- a/github/event_test.go
+++ b/github/event_test.go
@@ -8,37 +8,51 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConvertGithubEvent(t *testing.T) {
-	number := 1
-	action := "opened"
-	ownerName := "ninech"
-	owner := gh.User{Login: &ownerName}
-	fullname := "ninech/actuator"
-	name := "actuator"
-	branchName := "pr-1"
-	repo := gh.Repository{FullName: &fullname, Name: &name, Owner: &owner}
-	pr := gh.PullRequest{Number: &number, Head: &gh.PullRequestBranch{Ref: &branchName}}
+func TestEvent(t *testing.T) {
+	t.Run("ConvertGithubEvent", func(t *testing.T) {
+		t.Run("for the ping event", func(t *testing.T) {
+			originalEvent := &gh.PingEvent{}
 
-	originalEvent := &gh.PullRequestEvent{Action: &action, Number: &number, Repo: &repo, PullRequest: &pr}
+			internalEvent, ok := github.ConvertGithubEvent(originalEvent)
 
-	internalEvent, ok := github.ConvertGithubEvent(originalEvent)
+			assert.True(t, ok)
+			assert.IsType(t, &github.Event{}, internalEvent)
+			assert.Equal(t, github.PingEvent, internalEvent.Type)
+		})
 
-	assert.True(t, ok)
+		t.Run("for a pull request event", func(t *testing.T) {
+			number := 1
+			action := "opened"
+			ownerName := "ninech"
+			owner := gh.User{Login: &ownerName}
+			fullname := "ninech/actuator"
+			name := "actuator"
+			branchName := "pr-1"
+			repo := gh.Repository{FullName: &fullname, Name: &name, Owner: &owner}
+			pr := gh.PullRequest{Number: &number, Head: &gh.PullRequestBranch{Ref: &branchName}}
 
-	assert.Equal(t, action, internalEvent.Action)
-	assert.Equal(t, number, internalEvent.IssueNumber)
-	assert.Equal(t, name, internalEvent.RepositoryName)
-	assert.Equal(t, fullname, internalEvent.RepositoryFullname)
-	assert.Equal(t, ownerName, internalEvent.RepositoryOwner)
-	assert.Equal(t, branchName, internalEvent.HeadRef)
-	assert.Equal(t, github.PullRequestEvent, internalEvent.Type)
+			originalEvent := &gh.PullRequestEvent{Action: &action, Number: &number, Repo: &repo, PullRequest: &pr}
 
-	assert.Equal(t, originalEvent, internalEvent.OriginalEvent)
-}
+			internalEvent, ok := github.ConvertGithubEvent(originalEvent)
 
-func TestConvertGithubEventUnknown(t *testing.T) {
-	internalEvent, ok := github.ConvertGithubEvent("yolo")
+			assert.True(t, ok)
 
-	assert.False(t, ok)
-	assert.Nil(t, internalEvent)
+			assert.Equal(t, action, internalEvent.Action)
+			assert.Equal(t, number, internalEvent.IssueNumber)
+			assert.Equal(t, name, internalEvent.RepositoryName)
+			assert.Equal(t, fullname, internalEvent.RepositoryFullname)
+			assert.Equal(t, ownerName, internalEvent.RepositoryOwner)
+			assert.Equal(t, branchName, internalEvent.HeadRef)
+			assert.Equal(t, github.PullRequestEvent, internalEvent.Type)
+
+			assert.Equal(t, originalEvent, internalEvent.OriginalEvent)
+		})
+
+		t.Run("for an unknown event", func(t *testing.T) {
+			internalEvent, ok := github.ConvertGithubEvent("yolo")
+
+			assert.False(t, ok)
+			assert.Nil(t, internalEvent)
+		})
+	})
 }


### PR DESCRIPTION
Actuator now responds correctly to the Github ping event.
https://developer.github.com/webhooks/#ping-event